### PR TITLE
Fixed the sourcery AutoEquatable template.

### DIFF
--- a/Sourcery/AutoEquatable.stencil
+++ b/Sourcery/AutoEquatable.stencil
@@ -36,7 +36,7 @@ fileprivate func compareArrays<T>(lhs: [T], rhs: [T], compare: (_ lhs: T, _ rhs:
 // MARK: - {{ type.name }} AutoEquatable
 {% if not type.kind == "protocol" and not type.based.NSObject %}extension {{ type.name }}: Equatable {}{% endif %}
 {% if type.supertype.based.Equatable or type.supertype.implements.AutoEquatable or type.supertype|annotated:"AutoEquatable" %}THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoEquatable{% endif %}
-{{ type.accessLevel }} func == (lhs: {{ type.name }}, rhs: {{ type.name }}) -> Bool {
+public func == (lhs: {{ type.name }}, rhs: {{ type.name }}) -> Bool {
     {% if not type.kind == "protocol" %}
     {% call compareVariables type.storedVariables %}
     {% else %}
@@ -50,7 +50,7 @@ fileprivate func compareArrays<T>(lhs: [T], rhs: [T], compare: (_ lhs: T, _ rhs:
 {% for type in types.enums where type.implements.AutoEquatable or type|annotated:"AutoEquatable" %}
 // MARK: - {{ type.name }} AutoEquatable
 extension {{ type.name }}: Equatable {}
-{{ type.accessLevel }} func == (lhs: {{ type.name }}, rhs: {{ type.name }}) -> Bool {
+public func == (lhs: {{ type.name }}, rhs: {{ type.name }}) -> Bool {
     switch (lhs, rhs) {
     {% for case in type.cases %}
     {% if case.hasAssociatedValue %}


### PR DESCRIPTION
AutoEquatable is always required to be a public method. …plate.